### PR TITLE
Hide input search when data array is empty

### DIFF
--- a/src/SelectDropdown.js
+++ b/src/SelectDropdown.js
@@ -134,7 +134,7 @@ const SelectDropdown = (
   /* ******************** Render Methods ******************** */
   const renderSearchView = () => {
     return (
-      search && (
+      search && dataArr.length && (
         <Input
           searchViewWidth={buttonLayout.w}
           value={searchTxt}


### PR DESCRIPTION
I got this error when I typing search with empty data.

<img width="371" alt="image" src="https://github.com/totanvix/react-native-select-dropdown-customized/assets/41713692/51f78836-d569-485d-a922-d950c103ca5f">
